### PR TITLE
use mtr-tiny instead of mtr

### DIFF
--- a/roles/common/tasks/software.yml
+++ b/roles/common/tasks/software.yml
@@ -45,7 +45,7 @@
   - screen
   - htop
   - bmon
-  - mtr
+  - mtr-tiny
   - iotop
   - vim
   - apticron


### PR DESCRIPTION
mtr is compiled for X11 + ncurses whereas mtr-tiny only provides the ncurses interface
mtr: https://packages.debian.org/sid/mtr
mtr-tiny: https://packages.debian.org/sid/mtr-tiny