### PR TITLE
roles: firmware: take "https: no" into account

### DIFF
--- a/roles/firmware/tasks/main.yml
+++ b/roles/firmware/tasks/main.yml
@@ -66,8 +66,8 @@
   when: firmware_server == "replica" or firmware_server == "primary"
 
 - name: add firmware site
-  copy:
-    src: firmware.conf
+  template:
+    src: firmware.conf.j2
     dest: /etc/nginx/sites-enabled/firmware
     owner: root
     group: root

--- a/roles/firmware/templates/firmware.conf.j2
+++ b/roles/firmware/templates/firmware.conf.j2
@@ -1,6 +1,8 @@
 server {
 	listen 80;
 	listen [::]:80;
+
+{% if https %}
 	listen 443 ssl http2;
 	listen [::]:443 ssl http2;
 
@@ -27,6 +29,7 @@ server {
 
 	# verify chain of trust of OCSP response using Root CA and Intermediate certs
 	ssl_trusted_certificate /etc/letsencrypt/live/firmware.freifunk-vogtland.net/chain.pem;
+{% endif %}
 
         server_name firmware.freifunk-vogtland.net;
 


### PR DESCRIPTION
When trying to run "vagrant up vpn01" this currently fails with the
following error messages, even if "https: no" is set:

```
[...]
RUNNING HANDLER [firmware : restart nginx] *************************************
fatal: [vpn01]: FAILED! => {"changed": false, "msg": "Unable to restart service nginx.service: Job for nginx.service failed because the control process exited with error code.\nSee \"systemctl status nginx.service\" and \"journalctl -xe\" for details.\n"}

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
vpn01                      : ok=305  changed=246  unreachable=0    failed=1    skipped=2    rescued=0    ignored=0

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

With the following error from nginx:

```
systemd[1]: Starting A high performance web server and a reverse proxy server...
nginx[39458]: nginx: [emerg] cannot load certificate "/etc/letsencrypt/live/firmware.freifunk-vogtland.net/fullchain.pem": BIO_new_file() failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/letsencrypt/live/firmware>
nginx[39458]: nginx: configuration file /etc/nginx/nginx.conf test failed
```

Fixing this by taking using a template instead which takes the
"https: no" flag into account.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>