### PR TITLE
remove DHCP MTU option and AdvLinkMTU

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq.conf.j2
+++ b/roles/dnsmasq/templates/dnsmasq.conf.j2
@@ -26,7 +26,6 @@ dhcp-option=bat-{{ name }},6,{{ mesh[name]['ipv4']['subnet'] | ipaddr(1) | ipadd
 {% endfor %}
 
 dhcp-option=119,ffv
-dhcp-option=26,1394
 except-interface=lo
 
 read-ethers

--- a/roles/radvd/templates/radvd.conf.j2
+++ b/roles/radvd/templates/radvd.conf.j2
@@ -9,7 +9,6 @@ interface bat-{{ mesh_name }} {
 
   AdvManagedFlag off;
   AdvOtherConfigFlag on;
-  AdvLinkMTU 1280;
 
   MaxRtrAdvInterval 30;
 


### PR DESCRIPTION
There are some downsides with these options. The former is not consistently supported (and might lead to packet loss with some drivers/devices for unrouted traffic?). And both might lead to unnecessary fragmentation or smaller packets for unrouted, local traffic.

Therefore removing them to solely rely on ICMPv4 "Fragementation needed" and ICMPv6 "Packet Too Big" messages for routed traffic.