### PR TITLE
vagrant: fix disabling HTTPS via Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(2) do |config|
     ansible.extra_vars = {
         ansible_python_interpreter: "/usr/bin/env python3",
         gateway_if: "ens5",
-        https: "no",
+        https: false,
     }
     ansible.skip_tags=["icvpn", "ffmap-backup"]
   end


### PR DESCRIPTION
For a check in Jinja2 like this:

```
  {% if https %}
```

it expects 'https' to be a boolean. And not a string.

For a YAML file booleans are allowed to have various formats, like
True/true/1/yes/on and False/false/0/no/off etc. And ansible will
recognize such booleans and translate them in the Python booleans
Jinja2 expects.

The Vagrantfile is not YAML though but Ruby. And a string "no" will not
automatically be recognized as a boolean and will therefore end up in
Jinja2 as "{% if no %}", which will evaluate to true...

So using the proper presentation of a false boolean in Ruby.

Fixes: 429cc904c43d ("vagrant: Always disable HTTPS setup")
Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>